### PR TITLE
refactor: Update WebSocket message handling and receipt updates

### DIFF
--- a/skillarena_chat/main.py
+++ b/skillarena_chat/main.py
@@ -25,6 +25,7 @@ from .services.chat import (
     get_all_user_chats,
     get_chat,
     mark_messages_as_read,
+    mark_message_as_read,
 )
 from .utils.manager import manager
 from .utils.middlewares import AuthMiddleware
@@ -81,7 +82,16 @@ async def websocket_endpoint(websocket: WebSocket, token: str):
                 await process_websocket_message(websocket, data.get("data"), user_id)
 
             elif data.get("type") == "receipt_update":
+
+                # update the receipt for the message in the database
+                print(data.get("data"))
+                await mark_message_as_read(
+                    chat_id=data.get("data").get("chat_id"),
+                    message_id=data.get("data").get("message_id"),
+                )
+
                 await manager.send_receipt_update(
+                    chat_id=data.get("data").get("chat_id"),
                     user_id=data.get("data").get("user_id"),
                     message_id=data.get("data").get("message_id"),
                     updated_status=data.get("data").get("status"),

--- a/skillarena_chat/services/chat.py
+++ b/skillarena_chat/services/chat.py
@@ -4,6 +4,7 @@ from typing import Dict, List, Optional
 from ..db.database import db
 from ..models import ChatMessage, Message
 from .exceptions import DatabaseOperationError
+from bson import ObjectId
 
 
 async def get_chat(user_id1: str, user_id2: str) -> Optional[Dict]:
@@ -73,3 +74,17 @@ async def block_user(user_id: str, blocked_user_id: str):
 
     except Exception as e:
         raise DatabaseOperationError("Failed to block user") from e
+
+
+async def mark_message_as_read(chat_id: str, message_id: str):
+    messages = db.get_collection("messages")
+
+    try:
+        print("we are here")
+        await messages.update_one(
+            {"_id": ObjectId(chat_id), "messages.id": message_id},
+            {"$set": {"messages.$.status": "read"}},
+        )
+
+    except Exception as e:
+        raise DatabaseOperationError("Failed to mark message as read") from e

--- a/skillarena_chat/templates/chat.html
+++ b/skillarena_chat/templates/chat.html
@@ -218,7 +218,8 @@
 					const message_id = data.message_id;
 					const status = data.status;
 					const stop = data.stop || false;
-					const receiverId = document.getElementById("receiverId").value;
+					const receiver_id = document.getElementById("receiverId").value;
+					const chat_id = data.chat_id;
 
 					const message = document.getElementById(message_id);
 					if (message) {
@@ -230,7 +231,8 @@
 							JSON.stringify({
 								type: "receipt_update",
 								data: {
-									user_id: receiverId,
+									chat_id: chat_id,
+									user_id: receiver_id,
 									message_id: message_id,
 									status: status,
 									stop: true

--- a/skillarena_chat/utils/manager.py
+++ b/skillarena_chat/utils/manager.py
@@ -27,7 +27,12 @@ class ConnectionManager:
             )
 
     async def send_receipt_update(
-        self, message_id: str, user_id: str, updated_status: str, stop: bool = False
+        self,
+        chat_id: str,
+        message_id: str,
+        user_id: str,
+        updated_status: str,
+        stop: bool = False,
     ):
         if user_id in self.active_connections:
             await self.active_connections[user_id].send_text(
@@ -36,6 +41,7 @@ class ConnectionManager:
                         "type": "receipt_update",
                         "data": json.dumps(
                             {
+                                "chat_id": chat_id,
                                 "user_id": user_id,
                                 "message_id": message_id,
                                 "status": updated_status,

--- a/skillarena_chat/utils/services.py
+++ b/skillarena_chat/utils/services.py
@@ -61,11 +61,13 @@ async def handle_send_chat_message(chat_message: Message) -> None:
         )
 
         await manager.send_receipt_update(
+            chat_id=str(chat_doc["_id"]),
             user_id=chat_message.sender,
             message_id=chat_message.id,
             updated_status="delivered",
         )
         await manager.send_receipt_update(
+            chat_id=str(chat_doc["_id"]),
             user_id=chat_message.receiver,
             message_id=chat_message.id,
             updated_status="read",


### PR DESCRIPTION
Improve WebSocket message handling and receipt updates by introducing a new message type for receipt updates and adding logic to send receipt updates to the chat when a message is received or read. Also update the `send_receipt_update` method in the `ConnectionManager` to accept an additional `chat_id` parameter, allowing for stopping the propagation of receipt updates when a message is read.